### PR TITLE
Fix security hole

### DIFF
--- a/etc/miner.conf.donate
+++ b/etc/miner.conf.donate
@@ -10,7 +10,7 @@
     "scan-time": "60",
     "shares": "0",
     "kernel-path": "\/opt\/minepeon\/bin",
-    "api-allow": "W:0\/0",
+    "api-allow": "127.0.0.1",
     "pools": [
         {
             "url": "stratum.btcguild.com:3333",


### PR DESCRIPTION
Fix security hole by having BFG/CGminer API listen on localhost only as we don't have password protection on the API
